### PR TITLE
Changed migration template according to Kohana conventions

### DIFF
--- a/templates/migration.tpl
+++ b/templates/migration.tpl
@@ -10,8 +10,8 @@
 * add_index($table_name, $index_name, $columns, $index_type = 'normal')
 * remove_index($table_name, $index_name)
 */
-class {class_name} extends Migration
-{
+class {class_name} extends Migration {
+
 	public function up()
 	{
 {up}


### PR DESCRIPTION
According to the Kohana conventions:

``` php

// Correct
class Foo {
```

``` php

// Incorrect
class Foo
{
```

http://kohanaframework.org/3.3/guide/kohana/conventions#class-brackets
