### PR TITLE
Added hostname support. Added ability to change database in config.

### DIFF
--- a/classes/Minion/Migration.php
+++ b/classes/Minion/Migration.php
@@ -47,7 +47,7 @@ abstract class Minion_Migration extends Minion_Task {
 
 		if ($up OR $down)
 		{
-			Minion_Task::factory(array('task' => 'db:structure:dump', 'database' => 'default', 'file' => NULL))->execute();
+			Minion_Task::factory(array('task' => 'db:structure:dump', 'file' => NULL))->execute();
 		}
 	}
 

--- a/classes/Task/Db/Structure/Dump.php
+++ b/classes/Task/Db/Structure/Dump.php
@@ -15,17 +15,24 @@ class Task_DB_Structure_Dump extends Minion_Database {
 		'file' => FALSE,
 	);
 
-	protected function _execute(array $options)
+    protected function __construct()
+    {
+        $this->_options['database'] = Kohana::$config->load("migrations.database");
+        parent::__construct();
+    }
+
+    protected function _execute(array $options)
 	{
 		$db = $this->db_params($options['database']);
 
 		$file = $options['file'] ? $options['file'] : Kohana::$config->load("migrations.path").DIRECTORY_SEPARATOR.'schema.sql';
 		
-		$command = strtr("mysqldump -u:username :password --skip-comments --add-drop-database --add-drop-table --no-data :database | sed 's/AUTO_INCREMENT=[0-9]*\b//' > :file ", array(
+		$command = strtr("mysqldump -u:username :password -h :hostname --skip-comments --add-drop-database --add-drop-table --no-data :database | sed 's/AUTO_INCREMENT=[0-9]*\b//' > :file ", array(
 			':username' => $db['username'],
 			':password' => $db['password'] ? '-p'.$db['password'] : '',
 			':database' => $db['database'],
-			':file'      => $file
+			':hostname' => $db['hostname'],
+			':file'     => $file
 		));
 
 		Minion_CLI::write(Minion_CLI::color('Saving structure of database "'.$db['database'].'" to '.Debug::path($file), 'green'));

--- a/classes/Task/Db/Structure/Load.php
+++ b/classes/Task/Db/Structure/Load.php
@@ -18,6 +18,12 @@ class Task_DB_Structure_Load extends Minion_Database {
 		'file' => FALSE
 	);
 
+    protected function __construct()
+    {
+        $this->_options['database'] = Kohana::$config->load("migrations.database");
+        parent::__construct();
+    }
+
 	protected function _execute(array $options)
 	{
 		$db = $this->db_params($options['database']);
@@ -25,10 +31,11 @@ class Task_DB_Structure_Load extends Minion_Database {
 
 		if ($options['force'] === NULL OR 'yes' === Minion_CLI::read("This will destroy database ".$db['database']." Are you sure? [yes/NO]"))
 		{
-			$command = strtr("mysql -u:username :password :database < :file ", array(
+			$command = strtr("mysql -u:username :password -h :hostname :database < :file ", array(
 				':username' => $db['username'],
 				':password' => $db['password'] ? '-p'.$db['password'] : '',
 				':database' => $db['database'],
+                ':hostname' => $db['hostname'],
 				':file'     => $file
 			));
 


### PR DESCRIPTION
I've added hostname option for database structure load/dump functions. Early it was a problem when database was placed on other host.
Also. I've added ability to change database name in config file. It's helpful if we use diffretd database profiles for different environments. For example, migrations config can be like this:

``` php
return array(
    'log'      => NULL,
    'path'     => DOCROOT . 'migrations',
    'database' => Kohana::$environment
);
```
