### PR TITLE
Fix unnecessary double space after each 'create table' in schema.sql

### DIFF
--- a/classes/Task/Db/Structure/Dump.php
+++ b/classes/Task/Db/Structure/Dump.php
@@ -27,7 +27,7 @@ class Task_DB_Structure_Dump extends Minion_Database {
 
 		$file = $options['file'] ? $options['file'] : Kohana::$config->load("migrations.path").DIRECTORY_SEPARATOR.'schema.sql';
 		
-		$command = strtr("mysqldump -u:username :password -h :hostname --skip-comments --add-drop-database --add-drop-table --no-data :database | sed 's/AUTO_INCREMENT=[0-9]*\b//' > :file ", array(
+		$command = strtr("mysqldump -u:username :password -h :hostname --skip-comments --add-drop-database --add-drop-table --no-data :database | sed 's/ AUTO_INCREMENT=[0-9]*\b//' > :file ", array(
 			':username' => $db['username'],
 			':password' => $db['password'] ? '-p'.$db['password'] : '',
 			':database' => $db['database'],


### PR DESCRIPTION
Fix unnecessary double space after each 'create table' in schema.sql when ./minion db:structure:dump is executed.

Example of spaces before and after the fix between DEFAULT and CHARSET:

```diff
-CREATE TABLE foo(...) ENGINE=InnoDB DEFAULT  CHARSET=utf8;
+CREATE TABLE foo(...) ENGINE=InnoDB DEFAULT CHARSET=utf8;
```